### PR TITLE
refactor: MantineSimpleNavbar

### DIFF
--- a/src/components/navbars/MantineSimpleNavbar.vue
+++ b/src/components/navbars/MantineSimpleNavbar.vue
@@ -24,22 +24,26 @@ const footerLinks = [
   <nav class="navbar">
     <div class="main">
       <ul>
-        <li v-for="link in links" :key="link.label">
-          <router-link v-slot="{ href, navigate }" :to="{ name: link.name }" custom>
-            <BaseIcon size="24" :name="link.icon" class="icon" fill1="currentColor" />
-            <a role="link" :href="href" @click="onLinkClick($event, navigate)">{{ link.label }}</a>
-          </router-link>
-        </li>
+        <router-link v-for="link in links" :key="link.label" v-slot="{ href, navigate }" :to="{ name: link.name }" custom>
+          <li>
+            <a role="link" :href="href" @click="onLinkClick($event, navigate)">
+              <BaseIcon size="24" :name="link.icon" class="icon" fill1="currentColor" />
+              <span>{{ link.label }}</span>
+            </a>
+          </li>
+        </router-link>
       </ul>
     </div>
     <div class="footer">
       <ul>
-        <li v-for="link in footerLinks" :key="link.label">
-          <router-link v-slot="{ href, navigate }" :to="{ name: link.name }" custom>
-            <BaseIcon size="24" :name="link.icon" class="icon" />
-            <a role="link" :href="href" @click="onLinkClick($event, navigate)">{{ link.label }}</a>
-          </router-link>
-        </li>
+        <router-link v-for="link in footerLinks" :key="link.label" v-slot="{ href, navigate }" :to="{ name: link.name }" custom>
+          <li>
+            <a role="link" :href="href" @click="onLinkClick($event, navigate)">
+              <BaseIcon size="24" :name="link.icon" class="icon" />
+              <span>{{ link.label }}</span>
+            </a>
+          </li>
+        </router-link>
       </ul>
     </div>
   </nav>
@@ -61,7 +65,6 @@ const footerLinks = [
 
       li {
         line-height: 3em;
-        padding-left: 1em;
         display: flex;
         align-items: center;
         color: var(--vwa-c-text-2);
@@ -73,14 +76,17 @@ const footerLinks = [
 
         a {
           cursor: pointer;
-          display: block;
+          display: flex;
+          align-items: center;
+          width: 100%;
           padding: 0 2em 0 1em;
           color: var(--vwa-c-text-2);
           text-wrap: nowrap;
         }
-        // .icon {
-        //   color: var(--vwa-c-text-1)
-        // }
+        .icon {
+          // color: var(--vwa-c-text-1)
+          margin-right: 1em;
+        }
       }
 
     }


### PR DESCRIPTION
Вынес `router-link` на уровень выше + изменил стили, чтобы клик отрабатывался вне `<a>` тега.
Было:
![2024-03-10-214446_1366x768_scrot](https://github.com/vuesence/vue-webapp/assets/87827046/846fd856-c259-4323-ba0f-0d5d5e2570c5)
Стало:
![2024-03-10-214455_1366x768_scrot](https://github.com/vuesence/vue-webapp/assets/87827046/355e2d28-9a34-45fb-8c55-ccf0f140197c)
